### PR TITLE
explicitly enable building gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
   - 0.8
+# explicitly enable building gh-pages branch
+branches:
+  only:
+    - gh-pages
+    - /^.*$/


### PR DESCRIPTION
Since the gh-pages branch [isn't built by default](http://docs.travis-ci.com/user/build-configuration/#White--or-blacklisting-branches) we need to explicitly enable it.
