### PR TITLE
Use url as source

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,5 +31,6 @@
             "title": "Services",
             "type": "list"
         }
-    }
+    },
+    "geojson_source": "data.geojson"
 }

--- a/index.html
+++ b/index.html
@@ -10,10 +10,6 @@
     <!--[if IE]>
         <link rel="stylesheet" href="lib/leaflet/leaflet.ie.css" />
     <![endif]-->
-    <script type="text/javascript">
-      // this can be either a path to a local file or a remote URL
-      var geojson_source = 'data.geojson';
-    </script>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
     <!--[if IE]>
         <link rel="stylesheet" href="lib/leaflet/leaflet.ie.css" />
     <![endif]-->
+    <script type="text/javascript">
+      // this can be either a path to a local file or a remote URL
+      var geojson_source = 'data.geojson';
+    </script>
   </head>
 
   <body>

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,8 @@ Finda requires that your data is in GeoJSON format, since it's an open, web-frie
 
 If your data is not in GeoJSON format, you might try converting it using [Ogre](http://ogre.adc4gis.com/). We haven't used it ourselves, but it seems worth a try. We'll recommend an option we've tested in the future.
 
+To consume a remote URL instead of the local `data.geojson`, open up `index.html` and modify the `geojson_source` variable. By default, this variable loads the local `data.geojson`.
+
 
 ### Configure the application.
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Finda requires that your data is in GeoJSON format, since it's an open, web-frie
 
 If your data is not in GeoJSON format, you might try converting it using [Ogre](http://ogre.adc4gis.com/). We haven't used it ourselves, but it seems worth a try. We'll recommend an option we've tested in the future.
 
-To consume a remote URL instead of the local `data.geojson`, open up `index.html` and modify the `geojson_source` variable. By default, this variable loads the local `data.geojson`.
+To consume a remote URL instead of the local `data.geojson`, open up `config.json` and modify the `geojson_source` variable. By default, this variable loads the local `data.geojson`.
 
 
 ### Configure the application.

--- a/src/loader.js
+++ b/src/loader.js
@@ -10,7 +10,7 @@ define(
         $.getJSON('config.json', function(config) {
           this.trigger('config', config);
         }.bind(this));
-        $.getJSON('data.geojson', function(data) {
+        $.getJSON(geojson_source, function(data) {
           this.trigger('data', data);
         }.bind(this));
       });

--- a/src/loader.js
+++ b/src/loader.js
@@ -9,9 +9,11 @@ define(
         // load the data
         $.getJSON('config.json', function(config) {
           this.trigger('config', config);
-        }.bind(this));
-        $.getJSON(geojson_source, function(data) {
-          this.trigger('data', data);
+
+          // load the geojson
+          $.getJSON(config.geojson_source, function(data) {
+            this.trigger('data', data);
+          }.bind(this));
         }.bind(this));
       });
     };


### PR DESCRIPTION
Set `geojson_source` in `config.json` to tell finda to use a remote resource instead of the local `data.geojson` file. By default, still uses `data.geojson`.

This provides the basics for using dynamic, external resources instead of static GeoJSON.
