### PR TITLE
typos and deduping

### DIFF
--- a/data.geojson
+++ b/data.geojson
@@ -2089,7 +2089,7 @@
         ], 
         "contact_names": [], 
         "contact_emails": [], 
-        "youth_category": "CUT - NOT A MASSACHUSETST RESOURCE ", 
+        "youth_category": "CUT - NOT A MASSACHUSETTS RESOURCE ", 
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "", 
         "service_classes": [
@@ -3150,7 +3150,7 @@
         "organization_name": "Tapestry Health", 
         "community": "Great Barrington", 
         "services_offered": [
-          "heatlhcare", 
+          "healthcare", 
           "STI testing", 
           "HIV/AIDS"
         ], 
@@ -3187,7 +3187,7 @@
         "organization_name": "Tapestry Health", 
         "community": "North Adams", 
         "services_offered": [
-          "heatlhcare", 
+          "healthcare", 
           "STI testing", 
           "HIV/AIDS"
         ], 
@@ -3224,7 +3224,7 @@
         "organization_name": "Tapestry Health", 
         "community": "Pittsfield", 
         "services_offered": [
-          "heatlhcare", 
+          "healthcare", 
           "STI testing", 
           "HIV/AIDS"
         ], 
@@ -6463,7 +6463,7 @@
         "organization_name": "Holyoke Health Center", 
         "community": "Holyoke", 
         "services_offered": [
-          "heatlhcare", 
+          "healthcare", 
           "HIV/AIDS", 
           "primary care"
         ], 

--- a/src/data/facet.js
+++ b/src/data/facet.js
@@ -22,7 +22,7 @@ define(
       };
 
       this.filterFeatures = function(geojson, selected) {
-        // given a GeoJSON struture and a set of selected facets, return a
+        // given a GeoJSON structure and a set of selected facets, return a
         // GeoJSON structured filtered to the features which match the
         // selected facets
         if (selected) {
@@ -36,6 +36,9 @@ define(
                   if (!_.isArray(property)) {
                     property = [property];
                   }
+                  property = property.map(function (value) {
+                    return value.toLowerCase();
+                  });
                   // calculate the intersection of our selected values and
                   // the values on the given feature
                   var intersection = _.intersection(selected, property);
@@ -59,15 +62,18 @@ define(
           this.attr.config,
           _.bind(function(facetConfig, facet) {
             // adds up the count of the values on the given facet
-            return _.chain(this.attr.data.features)
+            var result = _.chain(this.attr.data.features)
               .map(function(feature) {
                 // values of the facet on the given feature
                 return feature.properties[facet];
               })
               .flatten(true)
+              .map(function (value) { return value.toLowerCase(); })
               .uniq()
-              .sortBy(function(value) { return value.toLowerCase(); })
+              .sortBy(function(value) { return value; })
               .value();
+
+            return result;
           }, this));
       };
 

--- a/src/data/facet.js
+++ b/src/data/facet.js
@@ -36,6 +36,7 @@ define(
                   if (!_.isArray(property)) {
                     property = [property];
                   }
+                  // lowercase facets for deduping purposes
                   property = property.map(function (value) {
                     return value.toLowerCase();
                   });
@@ -62,7 +63,7 @@ define(
           this.attr.config,
           _.bind(function(facetConfig, facet) {
             // adds up the count of the values on the given facet
-            var result = _.chain(this.attr.data.features)
+            return _.chain(this.attr.data.features)
               .map(function(feature) {
                 // values of the facet on the given feature
                 return feature.properties[facet];
@@ -72,8 +73,6 @@ define(
               .uniq()
               .sortBy(function(value) { return value; })
               .value();
-
-            return result;
           }, this));
       };
 


### PR DESCRIPTION
Changes:
- Certain locations had "heatlhcare" instead of "healthcare". Fixed.
- Facets are lowercased before indexing and counts, so that "healthcare" and "Healthcare" aren't counted or listed separately.

Does that seem useful?
