### PR TITLE
cleaning up data

### DIFF
--- a/data.geojson
+++ b/data.geojson
@@ -15,8 +15,8 @@
         "organization_name": "Generation Q South: Community Action Youth Programs", 
         "community": "Northampton", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.communityaction.us/our-groups-programs.html", 
         "phone_numbers": [
@@ -33,7 +33,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth 12-21"
+          "LGBTQ Youth 12-21"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -53,8 +53,8 @@
         "organization_name": "Generation Q North: Community Action Youth Programs", 
         "community": "Greenfield", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.communityaction.us/our-groups-programs.html", 
         "phone_numbers": [
@@ -89,8 +89,8 @@
         "organization_name": "PFLAG Franklin-Hampshire", 
         "community": "Shellbourne Falls", 
         "services_offered": [
-          "support group", 
-          "public education"
+          "Support Group", 
+          "Public Education"
         ], 
         "web_url": "http://community.pflag.org/page.aspx?pid=803", 
         "phone_numbers": [
@@ -107,7 +107,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "parent of LGBTQ youth"
+          "Parent of LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -127,8 +127,8 @@
         "organization_name": "TREE (Transgender Rights, Education and Empowerment): Community Action Youth Programs", 
         "community": "Greenfield", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.communityaction.us/our-groups-programs.html", 
         "phone_numbers": [
@@ -142,11 +142,11 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "Center-Based Basic Living and Personal Care Supports", 
+          "Center-based Basic Living and Personal Care Supports", 
           "Training and Skills Development"
         ], 
         "target_populations": [
-          "LGBTQ youth 12-21"
+          "LGBTQ Youth 12-21"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -166,8 +166,8 @@
         "organization_name": "TREE (Transgender Rights, Education and Empowerment): Community Action Youth Programs", 
         "community": "Northampton", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.communityaction.us/our-groups-programs.html", 
         "phone_numbers": [
@@ -181,11 +181,11 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "Center-Based Basic Living and Personal Care Supports", 
+          "Center-based Basic Living and Personal Care Supports", 
           "Training and Skills Development"
         ], 
         "target_populations": [
-          "LGBTQ youth 12-21"
+          "LGBTQ Youth 12-21"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -205,11 +205,11 @@
         "organization_name": "Tapestry Health", 
         "community": "Greenfield", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS", 
-          "referrals ", 
-          "housing services"
+          "Referrals", 
+          "Housing Services"
         ], 
         "web_url": "http://www.tapestryhealth.org", 
         "phone_numbers": [
@@ -224,7 +224,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "all, with specializations in both youth and LGBTQ folks"
+          "All, With Specializations In Both Youth and LGBTQ Folks"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -244,9 +244,9 @@
         "organization_name": "BRAGLY", 
         "community": "Brockton", 
         "services_offered": [
-          "social group", 
-          "support group", 
-          "STI testing"
+          "Social Group", 
+          "Support Group", 
+          "STI Testing"
         ], 
         "web_url": "http://www.healthimperatives.org/glys/bragly", 
         "phone_numbers": [
@@ -263,7 +263,7 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [], 
         "age_range": "", 
@@ -284,8 +284,8 @@
         "organization_name": "SSHAGLY (South Shore Alliance of Gay and Lesbian Youth)", 
         "community": "Norwell", 
         "services_offered": [
-          "social group", 
-          "support group"
+          "Social Group", 
+          "Support Group"
         ], 
         "web_url": "https://www.facebook.com/sshagly.southshore", 
         "phone_numbers": [
@@ -301,7 +301,7 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [], 
         "age_range": "", 
@@ -322,9 +322,9 @@
         "organization_name": "The GLBT Youth Support Project and OutHealth!", 
         "community": "Brockton", 
         "services_offered": [
-          "resources", 
-          "training and technical assistance", 
-          "risk assessment"
+          "Resources", 
+          "Training and Technical Assistance", 
+          "Risk Assessment"
         ], 
         "web_url": "http://www.hcsm.org/glys/home", 
         "phone_numbers": [
@@ -341,7 +341,7 @@
         "service_class_level_1": "Training and Educational Activities", 
         "service_class_level_2": "Cultural Competency Training", 
         "service_classes": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [
           "Ally"
@@ -365,10 +365,10 @@
         "community": "Brockton", 
         "services_offered": [
           "HIV/AIDS", 
-          "resources", 
-          "healthcare", 
-          "mental health services", 
-          "Substance abuse services"
+          "Resources", 
+          "Healthcare", 
+          "Mental Health Services", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://www.lhi.org/Homepage.aspx", 
         "phone_numbers": [
@@ -385,10 +385,10 @@
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Community Prevention, Education and Outreach", 
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -410,13 +410,13 @@
         "organization_name": "Child and Family Services", 
         "community": "Plymouth", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -429,12 +429,12 @@
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Clinical and Medical Counseling, Therapy, and Treatment", 
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -454,8 +454,8 @@
         "organization_name": "New Bedford Alliance for Gay and Lesbian Youth (NB-AGLY)", 
         "community": "New Bedford", 
         "services_offered": [
-          "social group", 
-          "support group"
+          "Social Group", 
+          "Support Group"
         ], 
         "web_url": "http://aperfectplace.org/", 
         "phone_numbers": [
@@ -471,7 +471,7 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [], 
         "age_range": "", 
@@ -492,11 +492,11 @@
         "organization_name": "UMass Dartmouth Center for Women, Gender and Sexuality and Pride Alliance", 
         "community": "North Dartmouth", 
         "services_offered": [
-          "social group", 
-          "counseling", 
-          "domestic violence services", 
-          "support group", 
-          "resources"
+          "Social Group", 
+          "Counseling", 
+          "Domestic Violence Services", 
+          "Support Group", 
+          "Resources"
         ], 
         "web_url": "http://www.umassd.edu/cwgs/", 
         "phone_numbers": [
@@ -512,7 +512,7 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "target_populations": [], 
         "age_range": "", 
@@ -533,13 +533,13 @@
         "organization_name": "Child and Family Services (Headquarters)", 
         "community": "New Bedford", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -554,9 +554,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -576,13 +576,13 @@
         "organization_name": "Child and Family Services (Mental Health Clinic)", 
         "community": "New Bedford", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -597,9 +597,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -619,13 +619,13 @@
         "organization_name": "Child and Family Services (Mental Health Clinic)", 
         "community": "New Bedford", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -640,9 +640,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -662,13 +662,13 @@
         "organization_name": "Child and Family Services", 
         "community": "New Bedford", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -683,9 +683,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -705,10 +705,10 @@
         "organization_name": "Journeys of Hope, Inc.", 
         "community": "Salem", 
         "services_offered": [
-          "homeless services", 
-          "case management", 
-          "service referrals ", 
-          "education services"
+          "Homeless Services", 
+          "Case Management", 
+          "Service Referrals", 
+          "Education Services"
         ], 
         "web_url": "http://johma.org/", 
         "phone_numbers": [
@@ -722,12 +722,12 @@
         ], 
         "youth_category": "Community Group", 
         "service_class_level_1": "Support Services", 
-        "service_class_level_2": "Case management; Para-professional Counseling, Therapy, and Support", 
+        "service_class_level_2": "Case Management; Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "Child/Adolescent Community Based Social Skills and Recreation"
+          "Child/adolescent Community Based Social Skills and Recreation"
         ], 
         "target_populations": [
-          "homeless youth"
+          "Homeless Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -749,8 +749,8 @@
         "organization_name": "MCVAGLY (Merrimack Valley Alliance of Gay, Lesbian, Bisexual, and Transgender Youth)", 
         "community": "North Andover", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "www.mcvagly.org", 
         "phone_numbers": [
@@ -771,7 +771,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -791,8 +791,8 @@
         "organization_name": "North Shore Alliance of Gay and Lesbian Youth (NAGLY)", 
         "community": "Salem", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.nagly.org/", 
         "phone_numbers": [
@@ -811,7 +811,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -831,9 +831,9 @@
         "organization_name": "Health Quarters", 
         "community": "Beverly", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
-          "training and technical assistance"
+          "Healthcare", 
+          "STI Testing", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.healthq.org/", 
         "phone_numbers": [
@@ -844,11 +844,11 @@
           "info@healthq.org"
         ], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment; Reproductive Health", 
         "service_classes": [], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -868,9 +868,9 @@
         "organization_name": "Health Quarters", 
         "community": "Haverhill", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
-          "training and technical assistance"
+          "Healthcare", 
+          "STI Testing", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.healthq.org/", 
         "phone_numbers": [
@@ -881,11 +881,11 @@
           "info@healthq.org"
         ], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment; Reproductive Health", 
         "service_classes": [], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -905,9 +905,9 @@
         "organization_name": "Lynn Community Health Center (Health Quarters)", 
         "community": "Lynn", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
-          "training and technical assistance"
+          "Healthcare", 
+          "STI Testing", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.healthq.org/", 
         "phone_numbers": [
@@ -918,11 +918,11 @@
           "info@healthq.org"
         ], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment; Reproductive Health", 
         "service_classes": [], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -942,9 +942,9 @@
         "organization_name": "Salem Family Health Center (Health Quarters)", 
         "community": "Salem", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
-          "training and technical assistance"
+          "Healthcare", 
+          "STI Testing", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.healthq.org/", 
         "phone_numbers": [
@@ -955,11 +955,11 @@
           "info@healthq.org"
         ], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment; Sexual Health", 
         "service_classes": [], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -979,13 +979,13 @@
         "organization_name": "Child and Family Services", 
         "community": "Lawrence", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -1000,9 +1000,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -1022,10 +1022,10 @@
         "organization_name": "Nantucket AIDS Network", 
         "community": "Nantucket", 
         "services_offered": [
-          "STI testing", 
-          "case management", 
-          "referrals", 
-          "training and technical assistance"
+          "STI Testing", 
+          "Case Management", 
+          "Referrals", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.nantucketaids.org/home.php", 
         "phone_numbers": [
@@ -1046,9 +1046,9 @@
           "Case Management"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "Individuals living with Hepatitis C", 
+        "age_range": "Individuals Living With Hepatitis C", 
         "additional_notes": []
       }
     }, 
@@ -1066,7 +1066,7 @@
         "organization_name": "Younger Bi/Fluid Group (Bisexual Resource Center)", 
         "community": "Somerville", 
         "services_offered": [
-          "support group"
+          "Support Group"
         ], 
         "web_url": "http://www.biresource.net/bostongroups.shtml", 
         "phone_numbers": [
@@ -1083,7 +1083,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -1105,8 +1105,8 @@
         "organization_name": "Cambridge Health Alliance - Broadway Health Center", 
         "community": "Somerville", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1115,13 +1115,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_1": "Health Services", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1141,8 +1141,8 @@
         "organization_name": "Cambridge Health Alliance - Cambridge Family Health", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1151,13 +1151,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1177,8 +1177,8 @@
         "organization_name": "Cambridge Health Alliance - Cambridge Family Health North", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1187,13 +1187,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1213,8 +1213,8 @@
         "organization_name": "Cambridge Health Alliance - Cambridge Pediatrics", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1223,13 +1223,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1249,8 +1249,8 @@
         "organization_name": "Cambridge Health Alliance - Cambridge Primary Care Center", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1259,13 +1259,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1285,8 +1285,8 @@
         "organization_name": "Cambridge Health Alliance - Cambridge Teen Health Center", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1295,13 +1295,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1321,8 +1321,8 @@
         "organization_name": "Cambridge Health Alliance - East Cambridge Health Center", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1331,13 +1331,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1357,8 +1357,8 @@
         "organization_name": "Cambridge Health Alliance - Everett Family Health Center", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1367,13 +1367,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1393,8 +1393,8 @@
         "organization_name": "Cambridge Health Alliance - Everett Teen Health Center", 
         "community": "Everett", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1403,13 +1403,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1429,8 +1429,8 @@
         "organization_name": "Cambridge Health Alliance - Malden Family Medicine Center", 
         "community": "Malden", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1439,13 +1439,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1465,8 +1465,8 @@
         "organization_name": "Cambridge Health Alliance - Revere Family Health Center", 
         "community": "Revere", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1475,13 +1475,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1501,8 +1501,8 @@
         "organization_name": "Cambridge Health Alliance - Somerville Hospital Primary Care", 
         "community": "Somerville", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1511,13 +1511,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1537,8 +1537,8 @@
         "organization_name": "Cambridge Health Alliance - Somerville Teen Connection", 
         "community": "Somerville", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1547,13 +1547,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1573,8 +1573,8 @@
         "organization_name": "Cambridge Health Alliance - Union Square Family Health", 
         "community": "Somerville", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1583,13 +1583,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1609,8 +1609,8 @@
         "organization_name": "Cambridge Health Alliance - Windsor Street Health Center ", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1619,13 +1619,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1645,9 +1645,9 @@
         "organization_name": "Cambridge Health Alliance - Anna May Powers Center", 
         "community": "Everett", 
         "services_offered": [
-          "healthcare", 
-          "mental health services", 
-          "counseling"
+          "Healthcare", 
+          "Mental Health Services", 
+          "Counseling"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1656,13 +1656,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -1684,10 +1684,10 @@
         "organization_name": "Cambridge Health Alliance - Central Street Health Center", 
         "community": "Somerville", 
         "services_offered": [
-          "healthcare", 
-          "mental health services", 
-          "counseling", 
-          "substance abuse services"
+          "Healthcare", 
+          "Mental Health Services", 
+          "Counseling", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1696,13 +1696,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -1724,11 +1724,11 @@
         "organization_name": "Cambridge Health Alliance - Zinberg HIV Clinic", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "counseling", 
+          "Healthcare", 
+          "Counseling", 
           "HIV/AIDS", 
-          "primary care", 
-          "mental health services"
+          "Primary Care", 
+          "Mental Health Services"
         ], 
         "web_url": "http://www.challiance.org/Main/Home.aspx", 
         "phone_numbers": [
@@ -1737,13 +1737,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -1765,7 +1765,7 @@
         "organization_name": "Davis Square Family Practice: Dr. Deborah Bershel", 
         "community": "Somerville", 
         "services_offered": [
-          "healthcare"
+          "Healthcare"
         ], 
         "web_url": "http://dsfamilypractice.com/transgender.php", 
         "phone_numbers": [
@@ -1774,13 +1774,13 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Primary Care Services", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "transgender youth"
+          "Transgender Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1800,10 +1800,10 @@
         "organization_name": "Dr. Nicole Issa, PsyD, LMHC", 
         "community": "Cambridge", 
         "services_offered": [
-          "healthcare", 
-          "mental health", 
-          "counseling", 
-          "training and technical assistance"
+          "Healthcare", 
+          "Mental Health", 
+          "Counseling", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://drnicoleissa.com/", 
         "phone_numbers": [
@@ -1814,13 +1814,13 @@
           "drnicoleissa@yahoo.com"
         ], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_1": "Health Services", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment "
+          "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1840,14 +1840,14 @@
         "organization_name": "Dustin Saldarriaga (at Community Legal Services and Counseling Center)", 
         "community": "Cambridge", 
         "services_offered": [
-          "referrals ", 
-          "legal services", 
-          "case management", 
-          "immigration services", 
-          "housing services", 
-          "employment services", 
-          "support group", 
-          "counseling"
+          "Referrals", 
+          "Legal Services", 
+          "Case Management", 
+          "Immigration Services", 
+          "Housing Services", 
+          "Employment Services", 
+          "Support Group", 
+          "Counseling"
         ], 
         "web_url": "clsacc.org/immigration.html", 
         "phone_numbers": [
@@ -1866,7 +1866,7 @@
           "Case Management"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1886,9 +1886,9 @@
         "organization_name": "GLBT Commission: City of Cambridge", 
         "community": "Cambridge", 
         "services_offered": [
-          "public education", 
-          "public education ", 
-          "resources"
+          "Public Education", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "http://www.cambridgema.gov/glbt.aspx", 
         "phone_numbers": [
@@ -1905,7 +1905,7 @@
           "Capacity Building"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -1925,9 +1925,9 @@
         "organization_name": "Greater Boston PFLAG", 
         "community": "Waltham", 
         "services_offered": [
-          "support group", 
-          "public education", 
-          "resources"
+          "Support Group", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "http://www.gbpflag.org/", 
         "phone_numbers": [
@@ -1944,9 +1944,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "parent"
+          "Parent"
         ], 
-        "age_range": "ally", 
+        "age_range": "Ally", 
         "additional_notes": []
       }
     }, 
@@ -1964,8 +1964,8 @@
         "organization_name": "Harvard QRC (Queer Resource Center", 
         "community": "Cambridge", 
         "services_offered": [
-          "social group", 
-          "resources"
+          "Social Group", 
+          "Resources"
         ], 
         "web_url": "http://www.hcs.harvard.edu/~harvardqrc/index.html", 
         "phone_numbers": [
@@ -1982,7 +1982,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2004,10 +2004,10 @@
         "organization_name": "lgbt @ MIT (including Rainbow Lounge)", 
         "community": "Cambridge", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "counseling", 
-          "public education"
+          "Support Group", 
+          "Social Group", 
+          "Counseling", 
+          "Public Education"
         ], 
         "web_url": "http://lbgt.mit.edu/", 
         "phone_numbers": [
@@ -2024,7 +2024,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2046,7 +2046,7 @@
         "organization_name": "Lowell Community Health Center LGBT Youth Group", 
         "community": "Lowell", 
         "services_offered": [
-          "support group"
+          "Support Group"
         ], 
         "web_url": "http://www.lchealth.org/support.shtml", 
         "phone_numbers": [
@@ -2061,7 +2061,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2081,7 +2081,7 @@
         "organization_name": "National Gay and Lesbian Task Force", 
         "community": "Cambridge", 
         "services_offered": [
-          "public education"
+          "Public Education"
         ], 
         "web_url": "http://www.thetaskforce.org/issues/youth", 
         "phone_numbers": [
@@ -2089,14 +2089,14 @@
         ], 
         "contact_names": [], 
         "contact_emails": [], 
-        "youth_category": "CUT - NOT A MASSACHUSETST RESOURCE ", 
+        "youth_category": "CUT - NOT A MASSACHUSETST RESOURCE", 
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "", 
         "service_classes": [
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2116,10 +2116,10 @@
         "organization_name": "Somerville Office of the LGBT Liaison", 
         "community": "Somerville", 
         "services_offered": [
-          "public education", 
-          "resources", 
-          "training and technical assistance", 
-          "referrals"
+          "Public Education", 
+          "Resources", 
+          "Training and Technical Assistance", 
+          "Referrals"
         ], 
         "web_url": "http://www.ci.somerville.ma.us/departments/health/somerville-commissions/lgbt", 
         "phone_numbers": [
@@ -2136,9 +2136,9 @@
           "Case Management"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "family", 
+        "age_range": "Family", 
         "additional_notes": []
       }
     }, 
@@ -2156,10 +2156,10 @@
         "organization_name": "Tufts University LGBT Center", 
         "community": "Medford", 
         "services_offered": [
-          "public education", 
-          "social group", 
-          "support group", 
-          "resources"
+          "Public Education", 
+          "Social Group", 
+          "Support Group", 
+          "Resources"
         ], 
         "web_url": "http://ase.tufts.edu/lgbt/resources/index.asp", 
         "phone_numbers": [
@@ -2179,7 +2179,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2201,7 +2201,7 @@
         "organization_name": "Wayside Youth", 
         "community": "Framingham", 
         "services_offered": [
-          "outreach to homeless and at-risk LGBTQ youth"
+          "Outreach To Homeless and At-risk LGBTQ Youth"
         ], 
         "web_url": "http://www.waysideyouth.org/", 
         "phone_numbers": [
@@ -2211,12 +2211,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth (homeless and at risk)"
+          "LGBTQ Youth (homeless and At Risk)"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2236,7 +2236,7 @@
         "organization_name": "Wayside Youth", 
         "community": "Framingham", 
         "services_offered": [
-          "outreach to homeless and at-risk LGBTQ youth"
+          "Outreach To Homeless and At-risk LGBTQ Youth"
         ], 
         "web_url": "http://www.waysideyouth.org/", 
         "phone_numbers": [
@@ -2246,12 +2246,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth (homeless and at risk)"
+          "LGBTQ Youth (homeless and At Risk)"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2271,7 +2271,7 @@
         "organization_name": "Wayside Youth", 
         "community": "Waltham", 
         "services_offered": [
-          "outreach to homeless and at-risk LGBTQ youth"
+          "Outreach To Homeless and At-risk LGBTQ Youth"
         ], 
         "web_url": "http://www.waysideyouth.org/", 
         "phone_numbers": [
@@ -2281,12 +2281,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth (homeless and at risk)"
+          "LGBTQ Youth (homeless and At Risk)"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2306,7 +2306,7 @@
         "organization_name": "Wayside Youth", 
         "community": "Watertown", 
         "services_offered": [
-          "outreach to homeless and at-risk LGBTQ youth"
+          "Outreach To Homeless and At-risk LGBTQ Youth"
         ], 
         "web_url": "http://www.waysideyouth.org/", 
         "phone_numbers": [
@@ -2316,12 +2316,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth (homeless and at risk)"
+          "LGBTQ Youth (homeless and At Risk)"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2341,7 +2341,7 @@
         "organization_name": "Wayside Youth", 
         "community": "Malden", 
         "services_offered": [
-          "outreach to homeless and at-risk LGBTQ youth"
+          "Outreach To Homeless and At-risk LGBTQ Youth"
         ], 
         "web_url": "http://www.waysideyouth.org/", 
         "phone_numbers": [
@@ -2351,12 +2351,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth (homeless and at risk)"
+          "LGBTQ Youth (homeless and At Risk)"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2376,14 +2376,14 @@
         "organization_name": "Youth on Fire", 
         "community": "Cambridge", 
         "services_offered": [
-          "shelter services", 
-          "healthcare", 
-          "support group", 
-          "public education", 
-          "referrals", 
-          "mental healh services", 
-          "housing services", 
-          "STI testing"
+          "Shelter Services", 
+          "Healthcare", 
+          "Support Group", 
+          "Public Education", 
+          "Referrals", 
+          "Mental Healh Services", 
+          "Housing Services", 
+          "STI Testing"
         ], 
         "web_url": "http://www.aac.org/about/our-work/youth-on-fire.html", 
         "phone_numbers": [
@@ -2395,12 +2395,12 @@
         ], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2420,9 +2420,9 @@
         "organization_name": "Lowell Community Health Center (Health Quarters)", 
         "community": "Lowell", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
-          "training and technical assistance"
+          "Healthcare", 
+          "STI Testing", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.healthq.org/", 
         "phone_numbers": [
@@ -2433,13 +2433,13 @@
           "info@healthq.org"
         ], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
+        "service_class_level_1": "Health Services", 
         "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment; Sexual Health", 
         "service_classes": [
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2460,10 +2460,10 @@
         "community": "Lowell", 
         "services_offered": [
           "HIV/AIDS", 
-          "resources", 
-          "healthcare", 
-          "mental health services", 
-          "Substance abuse services"
+          "Resources", 
+          "Healthcare", 
+          "Mental Health Services", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://www.lhi.org/Homepage.aspx", 
         "phone_numbers": [
@@ -2480,7 +2480,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2502,8 +2502,8 @@
         "organization_name": "More than Words", 
         "community": "Waltham", 
         "services_offered": [
-          "career skills", 
-          "leadership development"
+          "Career Skills", 
+          "Leadership Development"
         ], 
         "web_url": "http://mtwyouth.org/", 
         "phone_numbers": [
@@ -2520,7 +2520,7 @@
           "Education, Vocational and Skills Training"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2542,9 +2542,9 @@
         "organization_name": "Teen Empowerment", 
         "community": "Somerville", 
         "services_offered": [
-          "career skills", 
-          "leadership development", 
-          "public education"
+          "Career Skills", 
+          "Leadership Development", 
+          "Public Education"
         ], 
         "web_url": "http://www.teenempowerment.org/", 
         "phone_numbers": [
@@ -2561,7 +2561,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2584,12 +2584,12 @@
         "organization_name": "CASPAR Youth Services", 
         "community": "Somerville", 
         "services_offered": [
-          "substance abuse services", 
-          "drop in center", 
-          "support group", 
-          "employment services", 
-          "case management", 
-          "referrals"
+          "Substance Abuse Services", 
+          "Drop In Center", 
+          "Support Group", 
+          "Employment Services", 
+          "Case Management", 
+          "Referrals"
         ], 
         "web_url": "http://www.casparinc.org", 
         "phone_numbers": [
@@ -2601,13 +2601,13 @@
         ], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach, and Stabilization Services", 
           "Case Management"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -2629,10 +2629,10 @@
         "organization_name": "TIFFANY Club of New England", 
         "community": "Waltham", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "referrals", 
-          "resources"
+          "Support Group", 
+          "Social Group", 
+          "Referrals", 
+          "Resources"
         ], 
         "web_url": "http://tcne.org/", 
         "phone_numbers": [
@@ -2647,7 +2647,7 @@
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2667,9 +2667,9 @@
         "organization_name": "WAGLY (West Suburban Alliance of Gay, Lesbian, Bisexual, Transgender and Queer Youth)", 
         "community": "Wellesley Hills", 
         "services_offered": [
-          "social group", 
-          "support group", 
-          "leadership development"
+          "Social Group", 
+          "Support Group", 
+          "Leadership Development"
         ], 
         "web_url": "www.wagly.org", 
         "phone_numbers": [
@@ -2686,7 +2686,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2706,10 +2706,10 @@
         "organization_name": "AIDS Support Group of Cape Cod (Hyannis Office)", 
         "community": "Hyannis", 
         "services_offered": [
-          "support group", 
-          "case management", 
-          "STI testing", 
-          "public education"
+          "Support Group", 
+          "Case Management", 
+          "STI Testing", 
+          "Public Education"
         ], 
         "web_url": "http://www.asgcc.org/", 
         "phone_numbers": [
@@ -2724,7 +2724,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2744,9 +2744,9 @@
         "organization_name": "AIDS Support Group of Cape Cod (Provincetown Office)", 
         "community": "Provincetown", 
         "services_offered": [
-          "support group", 
-          "case management", 
-          "public education"
+          "Support Group", 
+          "Case Management", 
+          "Public Education"
         ], 
         "web_url": "http://www.asgcc.org/", 
         "phone_numbers": [
@@ -2761,7 +2761,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2781,10 +2781,10 @@
         "organization_name": "AIDS Support Group of Cape Cod (Prevention and Screening)", 
         "community": "Provincetown", 
         "services_offered": [
-          "support group", 
-          "case management", 
-          "STI testing", 
-          "public education"
+          "Support Group", 
+          "Case Management", 
+          "STI Testing", 
+          "Public Education"
         ], 
         "web_url": "http://www.asgcc.org/", 
         "phone_numbers": [
@@ -2799,7 +2799,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2819,13 +2819,13 @@
         "organization_name": "Child and Family Services (Cape Cod Office)", 
         "community": "Hyannis", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -2840,9 +2840,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -2862,13 +2862,13 @@
         "organization_name": "Child and Family Services (Lower Cape Cod Outreach Office)", 
         "community": "Harwich Port", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "case management", 
-          "referrals", 
-          "family support", 
-          "training and technical assistance", 
-          "adoption services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Case Management", 
+          "Referrals", 
+          "Family Support", 
+          "Training and Technical Assistance", 
+          "Adoption Services"
         ], 
         "web_url": "http://child-familyservices.org/cape-cod/", 
         "phone_numbers": [
@@ -2883,9 +2883,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally"
         ]
@@ -2905,9 +2905,9 @@
         "organization_name": "CIGSYA (Cape and Islands Gay and Straight Youth Alliance) (Now rebranded as Thrive!)", 
         "community": "Hyannis", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "leadership development"
+          "Support Group", 
+          "Social Group", 
+          "Leadership Development"
         ], 
         "web_url": "http://www.cigsya.org/CIGSYA_House_-_English/Welcome.html", 
         "phone_numbers": [
@@ -2927,7 +2927,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -2947,10 +2947,10 @@
         "organization_name": "PFLAG Cape Cod", 
         "community": "Orleans", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "public education", 
-          "resources"
+          "Support Group", 
+          "Social Group", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "http://www.pflagcapecod.org/", 
         "phone_numbers": [
@@ -2965,9 +2965,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "ally", 
+        "age_range": "Ally", 
         "additional_notes": []
       }
     }, 
@@ -2985,10 +2985,10 @@
         "organization_name": "Affirmative Counseling", 
         "community": "Pittsfield", 
         "services_offered": [
-          "support group", 
-          "counseling", 
-          "mental health services", 
-          "training and technical assistance"
+          "Support Group", 
+          "Counseling", 
+          "Mental Health Services", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "www.affirmativecounseling.net", 
         "phone_numbers": [
@@ -3009,9 +3009,9 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "family", 
+        "age_range": "Family", 
         "additional_notes": []
       }
     }, 
@@ -3029,9 +3029,9 @@
         "organization_name": "Berkshire Area Health Education Center: Youth Suicide Prevention Project", 
         "community": "Pittsfield", 
         "services_offered": [
-          "training and technical assistance", 
-          "resources", 
-          "suicide prevention"
+          "Training and Technical Assistance", 
+          "Resources", 
+          "Suicide Prevention"
         ], 
         "web_url": "http://www.berkshireahec.org/page.php?PageID=2067&PageName=Youth+Suicide+Prevention+Project", 
         "phone_numbers": [
@@ -3050,9 +3050,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "family", 
+        "age_range": "Family", 
         "additional_notes": []
       }
     }, 
@@ -3070,10 +3070,10 @@
         "organization_name": "Live Out Loud Youth Group", 
         "community": "Pittsfield", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "resources", 
-          "leadership development"
+          "Support Group", 
+          "Social Group", 
+          "Resources", 
+          "Leadership Development"
         ], 
         "web_url": "http://www.affirmativecounseling.net/liveoutloudyouthgroup.html", 
         "phone_numbers": [
@@ -3092,7 +3092,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3112,8 +3112,8 @@
         "organization_name": "PRIDE Berkshire Community College", 
         "community": "Pittsfield", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.facebook.com/pages/Pride-BCC/295380640479573", 
         "phone_numbers": [
@@ -3130,7 +3130,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ BCC students, faculty and staff"
+          "LGBTQ BCC Students, Faculty and Staff"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3150,8 +3150,8 @@
         "organization_name": "Tapestry Health", 
         "community": "Great Barrington", 
         "services_offered": [
-          "heatlhcare", 
-          "STI testing", 
+          "Heatlhcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org", 
@@ -3167,7 +3167,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3187,8 +3187,8 @@
         "organization_name": "Tapestry Health", 
         "community": "North Adams", 
         "services_offered": [
-          "heatlhcare", 
-          "STI testing", 
+          "Heatlhcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org", 
@@ -3204,7 +3204,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3224,8 +3224,8 @@
         "organization_name": "Tapestry Health", 
         "community": "Pittsfield", 
         "services_offered": [
-          "heatlhcare", 
-          "STI testing", 
+          "Heatlhcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org", 
@@ -3241,7 +3241,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3261,10 +3261,10 @@
         "organization_name": "PFLAG of Greater Worcester", 
         "community": "Worcester", 
         "services_offered": [
-          "support group", 
-          "public education ", 
-          "resources", 
-          "public education"
+          "Support Group", 
+          "Public Education", 
+          "Resources", 
+          "Public Education"
         ], 
         "web_url": "http://www.worcesterpflag.org/index.html", 
         "phone_numbers": [
@@ -3283,9 +3283,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "parent"
+          "Parent"
         ], 
-        "age_range": "LGBTQ youth", 
+        "age_range": "LGBTQ Youth", 
         "additional_notes": []
       }
     }, 
@@ -3303,14 +3303,14 @@
         "organization_name": "Safe Homes of Central Massachusetts / The Bridge", 
         "community": "Worcester", 
         "services_offered": [
-          "support group", 
-          "resources", 
-          "leadership development", 
-          "STI testing", 
+          "Support Group", 
+          "Resources", 
+          "Leadership Development", 
+          "STI Testing", 
           "HIV/AIDS", 
-          "training and technical assistance", 
-          "counseling", 
-          "social group"
+          "Training and Technical Assistance", 
+          "Counseling", 
+          "Social Group"
         ], 
         "web_url": "http://www.safehomesma.org/", 
         "phone_numbers": [
@@ -3324,11 +3324,11 @@
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "Child/ Adolescent/ Young Adult Intermediate-Term Stabilization", 
+          "Child/ Adolescent/ Young Adult Intermediate-term Stabilization", 
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -3350,9 +3350,9 @@
         "organization_name": "SWAGLY (Supporters of Worcester Gay and Lesbian Youth)", 
         "community": "Worcester", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "leadership development"
+          "Support Group", 
+          "Social Group", 
+          "Leadership Development"
         ], 
         "web_url": "www.swagly.org", 
         "phone_numbers": [
@@ -3369,7 +3369,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3389,8 +3389,8 @@
         "organization_name": "Worcester State University Pride Alliance", 
         "community": "Worcester", 
         "services_offered": [
-          "social group", 
-          "resources"
+          "Social Group", 
+          "Resources"
         ], 
         "web_url": "http://worcester.edu/StudentActivities/clubs/WSCPrideAlliance", 
         "phone_numbers": [
@@ -3407,7 +3407,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -3430,12 +3430,12 @@
         "community": "Worcester", 
         "services_offered": [
           "HIV/AIDS", 
-          "healthcare", 
-          "STI testing", 
-          "housing services", 
-          "counseling", 
-          "mental healh services", 
-          "support group"
+          "Healthcare", 
+          "STI Testing", 
+          "Housing Services", 
+          "Counseling", 
+          "Mental Healh Services", 
+          "Support Group"
         ], 
         "web_url": "http://www.aidsprojectworcester.org/", 
         "phone_numbers": [
@@ -3452,7 +3452,7 @@
           "Community Prevention, Education, and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3472,9 +3472,9 @@
         "organization_name": "15 West Coffeehouse", 
         "community": "Leominster", 
         "services_offered": [
-          "social group", 
-          "support group", 
-          "leadership development"
+          "Social Group", 
+          "Support Group", 
+          "Leadership Development"
         ], 
         "web_url": "http://www.firstchurchuu.org/outreach.html#glbt", 
         "phone_numbers": [
@@ -3491,7 +3491,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3511,9 +3511,9 @@
         "organization_name": "15 West Coffeehouse", 
         "community": "Fitchburg", 
         "services_offered": [
-          "social group", 
-          "support group", 
-          "leadership development"
+          "Social Group", 
+          "Support Group", 
+          "Leadership Development"
         ], 
         "web_url": "http://www.firstchurchuu.org/outreach.html#glbt", 
         "phone_numbers": [
@@ -3530,7 +3530,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3550,9 +3550,9 @@
         "organization_name": "American Civil Liberties Union of Massachusetts", 
         "community": "Worcester", 
         "services_offered": [
-          "legal services", 
-          "public education", 
-          "resources"
+          "Legal Services", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "http://www.aclum.org/ ", 
         "phone_numbers": [
@@ -3572,7 +3572,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ folks"
+          "LGBTQ Folks"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3592,7 +3592,7 @@
         "organization_name": "Wayside Youth", 
         "community": "Milford", 
         "services_offered": [
-          "outreach to homeless and at-risk LGBTQ youth"
+          "Outreach To Homeless and At-risk LGBTQ Youth"
         ], 
         "web_url": "http://www.waysideyouth.org/", 
         "phone_numbers": [
@@ -3602,12 +3602,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Health Services", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth (homeless and at risk)"
+          "LGBTQ Youth (homeless and At Risk)"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3627,11 +3627,11 @@
         "organization_name": "AIDS Action Committee", 
         "community": "Boston", 
         "services_offered": [
-          "healthcare", 
-          "public education", 
+          "Healthcare", 
+          "Public Education", 
           "HIV/AIDS", 
-          "STI testing", 
-          "resources"
+          "STI Testing", 
+          "Resources"
         ], 
         "web_url": "http://www.aac.org/about/", 
         "phone_numbers": [
@@ -3646,7 +3646,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3666,9 +3666,9 @@
         "organization_name": "GLAD (Gay and Lesbian Advocates and Defenders) ", 
         "community": "Boston", 
         "services_offered": [
-          "legal services", 
-          "resources", 
-          "public education"
+          "Legal Services", 
+          "Resources", 
+          "Public Education"
         ], 
         "web_url": "www.glad.org", 
         "phone_numbers": [
@@ -3683,7 +3683,7 @@
           "Hotline Support"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3703,8 +3703,8 @@
         "organization_name": "MA Commission on LGBT Youth", 
         "community": "Boston", 
         "services_offered": [
-          "resources", 
-          "public education"
+          "Resources", 
+          "Public Education"
         ], 
         "web_url": "www.mass.gov/cgly", 
         "phone_numbers": [
@@ -3718,10 +3718,10 @@
         "service_class_level_1": "Awareness", 
         "service_class_level_2": "Community Outreach, Education, and Engagement", 
         "service_classes": [
-          "Capacity Building "
+          "Capacity Building"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3741,7 +3741,7 @@
         "organization_name": "MA Department of Public Health--Safe Spaces for GLBTQ Youth", 
         "community": "Boston", 
         "services_offered": [
-          "resources"
+          "Resources"
         ], 
         "web_url": "http://www.mass.gov/eohhs/gov/departments/dph/programs/community-health/dvip/violence/safe-spaces.html", 
         "phone_numbers": [
@@ -3758,7 +3758,7 @@
           "Advocacy and Funding"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3779,7 +3779,7 @@
         "community": "Boston", 
         "services_offered": [
           "24 Hour Helpline, Community Education and Outreach", 
-          "suicide prevention"
+          "Suicide Prevention"
         ], 
         "web_url": "http://samaritanshope.org/", 
         "phone_numbers": [
@@ -3789,12 +3789,12 @@
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Awareness", 
-        "service_class_level_2": "Hotline services", 
+        "service_class_level_2": "Hotline Services", 
         "service_classes": [
           "Helpline"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3814,9 +3814,9 @@
         "organization_name": "American Civil Liberties Union of Massachusetts", 
         "community": "Boston", 
         "services_offered": [
-          "legal services", 
-          "public education", 
-          "resources"
+          "Legal Services", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "http://www.aclum.org/ ", 
         "phone_numbers": [
@@ -3833,7 +3833,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3853,10 +3853,10 @@
         "organization_name": "AA Central Service Committee of Eastern Mass", 
         "community": "Boston", 
         "services_offered": [
-          "referrals ", 
-          "substance abuse services", 
-          "support group", 
-          "public education"
+          "Referrals", 
+          "Substance Abuse Services", 
+          "Support Group", 
+          "Public Education"
         ], 
         "web_url": "http://www.aaboston.org/", 
         "phone_numbers": [
@@ -3864,14 +3864,14 @@
         ], 
         "contact_names": [], 
         "contact_emails": [], 
-        "youth_category": "Is this accessible to youth?", 
+        "youth_category": "Is This Accessible To Youth?", 
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3891,8 +3891,8 @@
         "organization_name": "Arlington Street Church Youth Outreach", 
         "community": "Boston", 
         "services_offered": [
-          "community outreach", 
-          "spirituality"
+          "Community Outreach", 
+          "Spirituality"
         ], 
         "web_url": "http://www.ascboston.org/", 
         "phone_numbers": [
@@ -3902,14 +3902,14 @@
         "contact_emails": [
           "office@ascboston.org"
         ], 
-        "youth_category": "Faith-based org", 
+        "youth_category": "Faith-based Org", 
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -3929,9 +3929,9 @@
         "organization_name": "Artists for Humanity", 
         "community": "South Boston", 
         "services_offered": [
-          "career skills", 
-          "leadership development", 
-          "recreation"
+          "Career Skills", 
+          "Leadership Development", 
+          "Recreation"
         ], 
         "web_url": "http://afhboston.org/", 
         "phone_numbers": [
@@ -3950,7 +3950,7 @@
           "Competitive Integrated Employment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -3972,14 +3972,14 @@
         "organization_name": "BAGLY (Boston Area Gay and Lesbian Youth)", 
         "community": "Boston", 
         "services_offered": [
-          "social group", 
-          "support group", 
+          "Social Group", 
+          "Support Group", 
           "STI Testing", 
           "HIV/AIDS", 
-          "leadership development", 
-          "public education", 
-          "resources", 
-          "referrals"
+          "Leadership Development", 
+          "Public Education", 
+          "Resources", 
+          "Referrals"
         ], 
         "web_url": "http://www.bagly.org/", 
         "phone_numbers": [
@@ -3996,7 +3996,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4018,14 +4018,14 @@
         "organization_name": "Boston GLASS ", 
         "community": "Boston", 
         "services_offered": [
-          "social group", 
-          "support group", 
+          "Social Group", 
+          "Support Group", 
           "STI Testing", 
           "HIV/AIDS", 
-          "drop in center", 
-          "leadership development", 
-          "public education", 
-          "referrals"
+          "Drop In Center", 
+          "Leadership Development", 
+          "Public Education", 
+          "Referrals"
         ], 
         "web_url": "http://www.jri.org/services/health-hiv-lgbtq-services/health-and-prevention-services/boston-glass", 
         "phone_numbers": [
@@ -4044,7 +4044,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth under 13-25"
+          "LGBTQ Youth Under 13-25"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4064,14 +4064,14 @@
         "organization_name": "Bridge Over Troubled Waters", 
         "community": "Boston", 
         "services_offered": [
-          "shelter services", 
-          "career skills", 
-          "education services", 
-          "healthcare", 
+          "Shelter Services", 
+          "Career Skills", 
+          "Education Services", 
+          "Healthcare", 
           "HIV/AIDS", 
-          "STI testing", 
-          "mental health services", 
-          "counseling"
+          "STI Testing", 
+          "Mental Health Services", 
+          "Counseling"
         ], 
         "web_url": "http://bridgeotw.org/", 
         "phone_numbers": [
@@ -4085,10 +4085,10 @@
         "service_class_level_1": "Support Services; Health Services", 
         "service_class_level_2": "Housing Services; Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
-          "Child/Adolescent Short-Term Stabilization, Emergency Placement"
+          "Child/adolescent Short-term Stabilization, Emergency Placement"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4110,10 +4110,10 @@
         "organization_name": "Bridging the Gap", 
         "community": "Roxbury", 
         "services_offered": [
-          "education services", 
-          "support group", 
-          "life skills", 
-          "career skills"
+          "Education Services", 
+          "Support Group", 
+          "Life Skills", 
+          "Career Skills"
         ], 
         "web_url": "http://btgboston.wordpress.com/", 
         "phone_numbers": [
@@ -4132,7 +4132,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "At risk/Court involved"
+          "At Risk/court Involved"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4154,10 +4154,10 @@
         "organization_name": "Children's Hospital Boston, Adolescent Medicine ", 
         "community": "Boston", 
         "services_offered": [
-          "healthcare ", 
+          "Healthcare", 
           "HIV/AIDS", 
-          "resources", 
-          "primary care"
+          "Resources", 
+          "Primary Care"
         ], 
         "web_url": "http://www.childrenshospital.org/az/Site2905/mainpageS2905P0.html", 
         "phone_numbers": [
@@ -4172,7 +4172,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4192,8 +4192,8 @@
         "organization_name": "Boston Children's Hospital, Psychiatry", 
         "community": "Boston", 
         "services_offered": [
-          "mental health services", 
-          "counseling"
+          "Mental Health Services", 
+          "Counseling"
         ], 
         "web_url": "http://www.childrenshospital.org/az/Site2905/mainpageS2905P0.html", 
         "phone_numbers": [
@@ -4208,7 +4208,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4228,10 +4228,10 @@
         "organization_name": "Boston Children's Hospital, Gender Management Services", 
         "community": "Boston", 
         "services_offered": [
-          "healthcare ", 
-          "counseling", 
-          "mental health services", 
-          "endocrinology"
+          "Healthcare", 
+          "Counseling", 
+          "Mental Health Services", 
+          "Endocrinology"
         ], 
         "web_url": "http://www.childrenshospital.org/clinicalservices/Site2280/mainpageS2280P0.html", 
         "phone_numbers": [
@@ -4246,7 +4246,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4267,7 +4267,7 @@
         "community": "Boston", 
         "services_offered": [
           "Obstetrics & Gynecology", 
-          "healthcare"
+          "Healthcare"
         ], 
         "web_url": "http://services.bidmc.org/Find_a_doc/doc_detail.asp?sid=41414642504443", 
         "phone_numbers": [
@@ -4282,7 +4282,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4302,8 +4302,8 @@
         "organization_name": "E.A.G.L.E. (Emerson's Alliance for Gays, Lesbians and Everyone)", 
         "community": "Boston", 
         "services_offered": [
-          "social group", 
-          "resources"
+          "Social Group", 
+          "Resources"
         ], 
         "web_url": "http://pages.emerson.edu/Organizations/EAGLE/index.html", 
         "phone_numbers": [
@@ -4320,7 +4320,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4342,11 +4342,11 @@
         "organization_name": "Fenway  Health Center", 
         "community": "Boston", 
         "services_offered": [
-          "primary care", 
-          "healthcare", 
-          "mental health services", 
+          "Primary Care", 
+          "Healthcare", 
+          "Mental Health Services", 
           "HIV/AIDS", 
-          "STI testing"
+          "STI Testing"
         ], 
         "web_url": "http://www.fenwayhealth.org/", 
         "phone_numbers": [
@@ -4361,7 +4361,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ folks"
+          "LGBTQ Folks"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4381,12 +4381,12 @@
         "organization_name": "Hispanic Black Gay Coalition", 
         "community": "Boston", 
         "services_offered": [
-          "social group", 
+          "Social Group", 
           "HIV/AIDS", 
           "STI Testing", 
-          "Support group", 
-          "leadership development", 
-          "public education"
+          "Support Group", 
+          "Leadership Development", 
+          "Public Education"
         ], 
         "web_url": "http://www.hbgc-boston.org", 
         "phone_numbers": [
@@ -4403,7 +4403,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4423,11 +4423,11 @@
         "organization_name": "Hyde Square Task Force", 
         "community": "Jamaica Plain", 
         "services_offered": [
-          "career skills", 
-          "leadership development", 
-          "education services", 
-          "recreation", 
-          "public education"
+          "Career Skills", 
+          "Leadership Development", 
+          "Education Services", 
+          "Recreation", 
+          "Public Education"
         ], 
         "web_url": "http://www.hydesquare.org/", 
         "phone_numbers": [
@@ -4444,7 +4444,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -4464,12 +4464,12 @@
         "organization_name": "Keshet Parent and Family Connection", 
         "community": "Jamaica Plain", 
         "services_offered": [
-          "support group", 
-          "training and technical assistance", 
-          "leadership development", 
-          "resources", 
-          "spirituality", 
-          "public education"
+          "Support Group", 
+          "Training and Technical Assistance", 
+          "Leadership Development", 
+          "Resources", 
+          "Spirituality", 
+          "Public Education"
         ], 
         "web_url": "http://www.keshetonline.org/program/support-families/", 
         "phone_numbers": [
@@ -4486,9 +4486,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "family", 
+        "age_range": "Family", 
         "additional_notes": []
       }
     }, 
@@ -4506,9 +4506,9 @@
         "organization_name": "K-Street Recovery", 
         "community": "Boston", 
         "services_offered": [
-          "support group", 
-          "substance abuse services", 
-          "mental health services"
+          "Support Group", 
+          "Substance Abuse Services", 
+          "Mental Health Services"
         ], 
         "web_url": "http://www.k-street.com/", 
         "phone_numbers": [
@@ -4526,7 +4526,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4549,10 +4549,10 @@
         "community": "Boston", 
         "services_offered": [
           "HIV/AIDS", 
-          "resources", 
-          "healthcare", 
-          "mental health services", 
-          "Substance abuse services"
+          "Resources", 
+          "Healthcare", 
+          "Mental Health Services", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://www.lhi.org/Homepage.aspx", 
         "phone_numbers": [
@@ -4569,7 +4569,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4592,9 +4592,9 @@
         "community": "Boston", 
         "services_offered": [
           "STI Testing", 
-          "support group", 
-          "leadership development", 
-          "drop in center", 
+          "Support Group", 
+          "Leadership Development", 
+          "Drop In Center", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.maphealth.org/programs/asian-pride/", 
@@ -4615,7 +4615,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4638,8 +4638,8 @@
         "organization_name": "More than Words", 
         "community": "South End", 
         "services_offered": [
-          "career skills", 
-          "leadership development"
+          "Career Skills", 
+          "Leadership Development"
         ], 
         "web_url": "http://mtwyouth.org/", 
         "phone_numbers": [
@@ -4656,7 +4656,7 @@
           "Education, Vocational and Skills Training"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4679,11 +4679,11 @@
         "community": "Jamaica Plain", 
         "services_offered": [
           "HIV/AIDS", 
-          "training and technical assistance", 
-          "public education", 
-          "STI testing", 
-          "support group", 
-          "referrals"
+          "Training and Technical Assistance", 
+          "Public Education", 
+          "STI Testing", 
+          "Support Group", 
+          "Referrals"
         ], 
         "web_url": "http://www.mac-boston.org/", 
         "phone_numbers": [
@@ -4702,7 +4702,7 @@
           "Clinical and Medical Diagnostics"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4725,8 +4725,8 @@
         "community": "Roxbury", 
         "services_offered": [
           "Recreation", 
-          "leadership development", 
-          "public education"
+          "Leadership Development", 
+          "Public Education"
         ], 
         "web_url": "http://www.projecthiphop.org/   ", 
         "phone_numbers": [
@@ -4738,12 +4738,12 @@
         ], 
         "youth_category": "Community Group", 
         "service_class_level_1": "Support Services", 
-        "service_class_level_2": "Recreation services; Community Outreach, Education, and Engagement", 
+        "service_class_level_2": "Recreation Services; Community Outreach, Education, and Engagement", 
         "service_classes": [
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "youth interested in hip hop"
+          "Youth Interested In Hip Hop"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4765,10 +4765,10 @@
         "organization_name": "Reflect and Strengthen ", 
         "community": "Dorcester", 
         "services_offered": [
-          "support groups", 
-          "life skills", 
-          "public education", 
-          "recreation"
+          "Support Groups", 
+          "Life Skills", 
+          "Public Education", 
+          "Recreation"
         ], 
         "web_url": "http://www.reflectandstrengthen.org/", 
         "phone_numbers": [
@@ -4785,7 +4785,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4808,12 +4808,12 @@
         "organization_name": "Sidney Borum Jr Health Center", 
         "community": "Boston", 
         "services_offered": [
-          "healthcare ", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS", 
-          "counseling", 
-          "primary care", 
-          "mental healh services"
+          "Counseling", 
+          "Primary Care", 
+          "Mental Healh Services"
         ], 
         "web_url": "http://sidneyborum.org/", 
         "phone_numbers": [
@@ -4830,9 +4830,9 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "individuals infected/affected by HIV/AIDS", 
+        "age_range": "Individuals Infected/affected By HIV/AIDS", 
         "additional_notes": [
           "12-29", 
           "At the Borum, we offer quality, open care to young adults ages 12\u201329 who need a health center that really gets them."
@@ -4853,13 +4853,13 @@
         "organization_name": "Southern Jamaica Plain Health Centers", 
         "community": "Jamaica Plain", 
         "services_offered": [
-          "healthcare ", 
-          "case management", 
-          "mental health services", 
-          "leadership development", 
-          "primary care", 
-          "public education", 
-          "recreation", 
+          "Healthcare", 
+          "Case Management", 
+          "Mental Health Services", 
+          "Leadership Development", 
+          "Primary Care", 
+          "Public Education", 
+          "Recreation", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.brighamandwomens.org/Departments_and_Services/medicine/services/primarycare/sjphc/default.aspx", 
@@ -4875,7 +4875,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4897,9 +4897,9 @@
         "organization_name": "Spontaneous Celebrations", 
         "community": "Jamaica Plain", 
         "services_offered": [
-          "recreation", 
-          "public education", 
-          "leadership development"
+          "Recreation", 
+          "Public Education", 
+          "Leadership Development"
         ], 
         "web_url": "http://www.spontaneouscelebrations.org/", 
         "phone_numbers": [
@@ -4919,7 +4919,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4941,9 +4941,9 @@
         "organization_name": "Suffolk University Rainbow Alliance", 
         "community": "Boston", 
         "services_offered": [
-          "social group", 
-          "support group", 
-          "public education"
+          "Social Group", 
+          "Support Group", 
+          "Public Education"
         ], 
         "web_url": "https://suffolk.collegiatelink.net/organization/rainbowalliance", 
         "phone_numbers": [
@@ -4960,7 +4960,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -4983,9 +4983,9 @@
         "organization_name": "Teen Empowerment", 
         "community": "Dorcester", 
         "services_offered": [
-          "career skills", 
-          "leadership development", 
-          "public education"
+          "Career Skills", 
+          "Leadership Development", 
+          "Public Education"
         ], 
         "web_url": "http://www.teenempowerment.org/", 
         "phone_numbers": [
@@ -5002,7 +5002,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5025,9 +5025,9 @@
         "organization_name": "Teen Empowerment", 
         "community": "Roxbury", 
         "services_offered": [
-          "career skills", 
-          "leadership development", 
-          "public education"
+          "Career Skills", 
+          "Leadership Development", 
+          "Public Education"
         ], 
         "web_url": "http://www.teenempowerment.org/", 
         "phone_numbers": [
@@ -5044,7 +5044,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5068,8 +5068,8 @@
         "community": "Boston", 
         "services_offered": [
           "Recreation", 
-          "leadership development", 
-          "public education"
+          "Leadership Development", 
+          "Public Education"
         ], 
         "web_url": "http://www.thetheateroffensive.org", 
         "phone_numbers": [
@@ -5089,7 +5089,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5111,10 +5111,10 @@
         "organization_name": "TransCEND", 
         "community": "Jamaica Plain", 
         "services_offered": [
-          "case management", 
+          "Case Management", 
           "HIV/AIDS", 
-          "support group", 
-          "healthcare"
+          "Support Group", 
+          "Healthcare"
         ], 
         "web_url": "http://transcendboston.org/en/about", 
         "phone_numbers": [
@@ -5131,9 +5131,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "individuals infected/affected by HIV/AIDS", 
+        "age_range": "Individuals Infected/affected By HIV/AIDS", 
         "additional_notes": [
           "TransCEND (Transgender Care and Education Needs Diversity) provides support and risk reduction services to transgender women (male to female). The program offers member support, assistance with accessing basic services, medical care, support groups, educational groups, risk reduction materials, and individual case management."
         ]
@@ -5153,10 +5153,10 @@
         "organization_name": "Transformation Center", 
         "community": "Roxbury", 
         "services_offered": [
-          "mental health services", 
-          "support group", 
-          "training and technical assistance", 
-          "substance abuse services"
+          "Mental Health Services", 
+          "Support Group", 
+          "Training and Technical Assistance", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://transformation-center.org/", 
         "phone_numbers": [
@@ -5175,7 +5175,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5199,13 +5199,13 @@
         "community": "Boston", 
         "services_offered": [
           "HIV/AIDS", 
-          "support group", 
-          "training and technical assistance", 
-          "Support group", 
-          "social group", 
-          "housing services", 
-          "referrals", 
-          "recreation"
+          "Support Group", 
+          "Training and Technical Assistance", 
+          "Support Group", 
+          "Social Group", 
+          "Housing Services", 
+          "Referrals", 
+          "Recreation"
         ], 
         "web_url": "http://www.vpi.org/boston/", 
         "phone_numbers": [
@@ -5245,9 +5245,9 @@
         "organization_name": "Amherst College Queer Resource Center", 
         "community": "Amherst", 
         "services_offered": [
-          "resources", 
-          "social group", 
-          "public education "
+          "Resources", 
+          "Social Group", 
+          "Public Education"
         ], 
         "web_url": "https://www.amherst.edu/campuslife/rainbow", 
         "phone_numbers": [
@@ -5264,7 +5264,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5287,8 +5287,8 @@
         "organization_name": "Eunice Aviles,. PsyD", 
         "community": "Amherst", 
         "services_offered": [
-          "mental health", 
-          "counseling"
+          "Mental Health", 
+          "Counseling"
         ], 
         "web_url": "http://euniceaviles.com/", 
         "phone_numbers": [
@@ -5308,7 +5308,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5330,8 +5330,8 @@
         "organization_name": "Food for Thought Books", 
         "community": "Amherst", 
         "services_offered": [
-          "recreation", 
-          "social group"
+          "Recreation", 
+          "Social Group"
         ], 
         "web_url": "http://www.foodforthoughtbooks.com/", 
         "phone_numbers": [
@@ -5348,7 +5348,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5370,8 +5370,8 @@
         "organization_name": "Generation Q North: Community Action Youth Programs", 
         "community": "Northampton", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.communityaction.us/our-groups-programs.html", 
         "phone_numbers": [
@@ -5388,7 +5388,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5410,8 +5410,8 @@
         "organization_name": "TREE (Transgender Rights, Education and Empowerment): Community Action Youth Programs", 
         "community": "Northampton", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://www.communityaction.us/our-groups-programs.html", 
         "phone_numbers": [
@@ -5422,14 +5422,14 @@
           "TREE@communityaction.us"
         ], 
         "youth_category": "Community Group", 
-        "service_class_level_1": "Center-Based Basic Living and Personal Care Supports", 
-        "service_class_level_2": "Center-Based Basic Living and Personal Care Supports", 
+        "service_class_level_1": "Center-based Basic Living and Personal Care Supports", 
+        "service_class_level_2": "Center-based Basic Living and Personal Care Supports", 
         "service_classes": [
-          "Center-Based Basic Living and Personal Care Supports", 
+          "Center-based Basic Living and Personal Care Supports", 
           "Training and Skills Development"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5452,8 +5452,8 @@
         "organization_name": "GLBTQA Youth Alliance Pride Zone", 
         "community": "Northampton", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "", 
         "phone_numbers": [
@@ -5472,7 +5472,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5495,9 +5495,9 @@
         "organization_name": "Hampshire College Queer Community Alliance ", 
         "community": "Amherst", 
         "services_offered": [
-          "resources", 
-          "social group", 
-          "support group"
+          "Resources", 
+          "Social Group", 
+          "Support Group"
         ], 
         "web_url": "http://www.hampshire.edu/studentlife/queercommunityalliancenter.htm", 
         "phone_numbers": [
@@ -5516,7 +5516,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5539,10 +5539,10 @@
         "organization_name": "LGBT Associates of Western Mass:  Dr. Shelley Janiczek Woodson and Dr. Brett-Genny Janiczek Beemyn ", 
         "community": "Granby", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "public education ", 
-          "training and technical assistance"
+          "Mental Health Services", 
+          "Counseling", 
+          "Public Education", 
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.masstherapist.com/LGBTQQIAServices.en.html", 
         "phone_numbers": [
@@ -5560,7 +5560,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5580,11 +5580,11 @@
       "properties": {
         "address": "32 Industrial Drive East\nHampshire, MA 01060", 
         "organization_name": "LGBT Coalition of Western Mass", 
-        "community": "Northampton ", 
+        "community": "Northampton", 
         "services_offered": [
-          "public education", 
-          "resources", 
-          "referrals"
+          "Public Education", 
+          "Resources", 
+          "Referrals"
         ], 
         "web_url": "http://www.lgbtcoalitionwma.org/", 
         "phone_numbers": [
@@ -5599,7 +5599,7 @@
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5621,8 +5621,8 @@
         "organization_name": "LGBT Jews & Allies", 
         "community": "Amherst", 
         "services_offered": [
-          "support group", 
-          "social group"
+          "Support Group", 
+          "Social Group"
         ], 
         "web_url": "http://umass.hillel.org/home.aspx", 
         "phone_numbers": [
@@ -5640,7 +5640,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5662,9 +5662,9 @@
         "organization_name": "PFLAG Northampton", 
         "community": "Northampton", 
         "services_offered": [
-          "support group", 
-          "public education", 
-          "resources"
+          "Support Group", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "", 
         "phone_numbers": [
@@ -5681,9 +5681,9 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "ally", 
+        "age_range": "Ally", 
         "additional_notes": []
       }
     }, 
@@ -5699,10 +5699,10 @@
       "properties": {
         "address": "7 College Lane\nWesley House\nHampshire, MA 01063", 
         "organization_name": "Resource Center for Gender and Sexuality", 
-        "community": "Northampton ", 
+        "community": "Northampton", 
         "services_offered": [
-          "resources", 
-          "public education"
+          "Resources", 
+          "Public Education"
         ], 
         "web_url": "http://www.smith.edu/ose/rcsg.php", 
         "phone_numbers": [
@@ -5719,7 +5719,7 @@
           "Education, Vocational and Skills Training"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5742,12 +5742,12 @@
         "organization_name": "Safe Passage", 
         "community": "Northampton", 
         "services_offered": [
-          "intimate parter violence", 
-          "shelter services", 
-          "legal services", 
-          "counseling", 
-          "public education", 
-          "support group"
+          "Intimate Parter Violence", 
+          "Shelter Services", 
+          "Legal Services", 
+          "Counseling", 
+          "Public Education", 
+          "Support Group"
         ], 
         "web_url": "http://www.safepass.org", 
         "phone_numbers": [
@@ -5758,12 +5758,12 @@
         "contact_emails": [], 
         "youth_category": "Community Group", 
         "service_class_level_1": "Support Services", 
-        "service_class_level_2": "Individual advocacy services", 
+        "service_class_level_2": "Individual Advocacy Services", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5785,8 +5785,8 @@
         "organization_name": "St. John's Episcopal Church", 
         "community": "Northampton", 
         "services_offered": [
-          "substance abuse services", 
-          "spirituality"
+          "Substance Abuse Services", 
+          "Spirituality"
         ], 
         "web_url": "http://www.stjohnsnorthampton.org", 
         "phone_numbers": [
@@ -5796,14 +5796,14 @@
         "contact_emails": [
           "stjohnsnorthampton@verizon.net"
         ], 
-        "youth_category": "Faith-based org", 
+        "youth_category": "Faith-based Org", 
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
           "Direct Prevention, Outreach and Stabilization Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5825,7 +5825,7 @@
         "organization_name": "Tapestry Health", 
         "community": "Florence", 
         "services_offered": [
-          "healthcare"
+          "Healthcare"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
         "phone_numbers": [
@@ -5840,7 +5840,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5862,8 +5862,8 @@
         "organization_name": "Tapestry Health", 
         "community": "Amherst", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
@@ -5879,7 +5879,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5901,8 +5901,8 @@
         "organization_name": "Tapestry Health", 
         "community": "Northampton", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
@@ -5918,7 +5918,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5940,11 +5940,11 @@
         "organization_name": "The Center for Women and Community", 
         "community": "Amherst", 
         "services_offered": [
-          "sexual assault services", 
-          "support group", 
-          "counseling", 
-          "domestic violence", 
-          "resources"
+          "Sexual Assault Services", 
+          "Support Group", 
+          "Counseling", 
+          "Domestic Violence", 
+          "Resources"
         ], 
         "web_url": "http://www.umass.edu/ewc", 
         "phone_numbers": [
@@ -5956,12 +5956,12 @@
         ], 
         "youth_category": "Health and Mental Health", 
         "service_class_level_1": "Support Services", 
-        "service_class_level_2": "Case management; Para-professional Counseling, Therapy, and Support", 
+        "service_class_level_2": "Case Management; Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
-          "Child/ Adolescent/ Young Adult Intermediate-Term Stabilization"
+          "Child/ Adolescent/ Young Adult Intermediate-term Stabilization"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -5983,11 +5983,11 @@
         "organization_name": "The Stonewall Center", 
         "community": "Amherst", 
         "services_offered": [
-          "support group", 
-          "public education", 
-          "resoures", 
-          "social group", 
-          "referrals"
+          "Support Group", 
+          "Public Education", 
+          "Resoures", 
+          "Social Group", 
+          "Referrals"
         ], 
         "web_url": "http://www.umass.edu/stonewall/", 
         "phone_numbers": [
@@ -6004,7 +6004,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6026,10 +6026,10 @@
         "organization_name": "True Colors ", 
         "community": "South Hadley", 
         "services_offered": [
-          "support group", 
-          "social group", 
-          "public education ", 
-          "resources"
+          "Support Group", 
+          "Social Group", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "https://www.mtholyoke.edu/org/colors/", 
         "phone_numbers": [
@@ -6046,7 +6046,7 @@
           "Clubhouse"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6067,10 +6067,10 @@
       "properties": {
         "address": "16 Center St.\nHampshire, MA 01060", 
         "organization_name": "Pat Jenkins, LICSW", 
-        "community": "Northampton ", 
+        "community": "Northampton", 
         "services_offered": [
-          "counseling", 
-          "mental health services"
+          "Counseling", 
+          "Mental Health Services"
         ], 
         "web_url": "http://patriciajenkinstherapy.com/", 
         "phone_numbers": [
@@ -6085,7 +6085,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6107,11 +6107,11 @@
         "organization_name": "Treehouse Foundation", 
         "community": "Easthampton", 
         "services_offered": [
-          "foster care services", 
-          "leadership development", 
-          "support group", 
-          "social group", 
-          "recreation"
+          "Foster Care Services", 
+          "Leadership Development", 
+          "Support Group", 
+          "Social Group", 
+          "Recreation"
         ], 
         "web_url": "http://refca.net/home-page", 
         "phone_numbers": [
@@ -6126,7 +6126,7 @@
           "Placement Services and Supports"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6149,9 +6149,9 @@
         "organization_name": "American Civil Liberties Union of Massachusetts", 
         "community": "Northampton", 
         "services_offered": [
-          "legal services", 
-          "public education", 
-          "resources"
+          "Legal Services", 
+          "Public Education", 
+          "Resources"
         ], 
         "web_url": "http://www.aclum.org/ ", 
         "phone_numbers": [
@@ -6168,7 +6168,7 @@
           "Community Prevention, Education and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ folks"
+          "LGBTQ Folks"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6188,10 +6188,10 @@
         "organization_name": "Tapestry Health Needle Exchange", 
         "community": "Northampton", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS", 
-          "needle exchange"
+          "Needle Exchange"
         ], 
         "web_url": "http://www.tapestryhealth.org/index.php/services/prevention/needle-exchange", 
         "phone_numbers": [
@@ -6206,7 +6206,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6228,9 +6228,9 @@
         "organization_name": "Mason Sqaure Neighbourhood Health", 
         "community": "Springfield", 
         "services_offered": [
-          "healthcare", 
+          "Healthcare", 
           "HIV/AIDS", 
-          "STI testing"
+          "STI Testing"
         ], 
         "web_url": "http://baystatehealth.com/Baystate/Main+Nav/About+Us/Locations/Baystate+Medical+Practices/Primary+Care/Mason+Square+Neighborhood+Health+Center", 
         "phone_numbers": [
@@ -6246,7 +6246,7 @@
           "Clicinical and Medical Diagnostics"
         ], 
         "target_populations": [
-          "Individuals infected/affected by HIV/AIDS"
+          "Individuals Infected/affected By HIV/AIDS"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6268,8 +6268,8 @@
         "organization_name": "Sharon Wretvel", 
         "community": "Springfield", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://baystatehealth.com/Baystate/Main+Nav/ch.Find+a+Doctor.Print", 
         "phone_numbers": [
@@ -6284,7 +6284,7 @@
           "Individual Primary Care Wellness"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6304,8 +6304,8 @@
         "organization_name": "Always Our Children", 
         "community": "Springfield", 
         "services_offered": [
-          "Support group", 
-          "spirituality"
+          "Support Group", 
+          "Spirituality"
         ], 
         "web_url": "", 
         "phone_numbers": [
@@ -6318,7 +6318,7 @@
           "annrun76@aol.com", 
           "swtsomay@aol.com"
         ], 
-        "youth_category": "Faith-based org", 
+        "youth_category": "Faith-based Org", 
         "service_class_level_1": "Support Services", 
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
@@ -6327,7 +6327,7 @@
         "target_populations": [
           "Parent"
         ], 
-        "age_range": "LGBTQ youth", 
+        "age_range": "LGBTQ Youth", 
         "additional_notes": []
       }
     }, 
@@ -6360,7 +6360,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6381,7 +6381,7 @@
         "community": "Holyoke", 
         "services_offered": [
           "Healthcare", 
-          "Primary care"
+          "Primary Care"
         ], 
         "web_url": "http://www.holyokepediatrics.com/_providers/_norton/index.html", 
         "phone_numbers": [
@@ -6398,7 +6398,7 @@
           "Individual Primary Care Wellness"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6418,10 +6418,10 @@
         "organization_name": "Holyoke Equal Rights Association (HERA)", 
         "community": "Holyoke", 
         "services_offered": [
-          "social group", 
-          "support group", 
-          "leadership development", 
-          "resources"
+          "Social Group", 
+          "Support Group", 
+          "Leadership Development", 
+          "Resources"
         ], 
         "web_url": "http://youthtaskforce.org/youth/h-e-r-a-2/", 
         "phone_numbers": [
@@ -6438,10 +6438,10 @@
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
           "Community Prevention, Education, and Outreach", 
-          "Child/Adolescent Community Based Social Skills and Recreation"
+          "Child/adolescent Community Based Social Skills and Recreation"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6463,9 +6463,9 @@
         "organization_name": "Holyoke Health Center", 
         "community": "Holyoke", 
         "services_offered": [
-          "heatlhcare", 
+          "Heatlhcare", 
           "HIV/AIDS", 
-          "primary care"
+          "Primary Care"
         ], 
         "web_url": "http://www.hhcinc.org/home.php", 
         "phone_numbers": [
@@ -6474,14 +6474,14 @@
         "contact_names": [], 
         "contact_emails": [], 
         "youth_category": "Health and Mental Health", 
-        "service_class_level_1": "Health Services ", 
-        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment ", 
+        "service_class_level_1": "Health Services", 
+        "service_class_level_2": "Clinical and Medical Counseling, Therapy, and Treatment", 
         "service_classes": [
-          "Clinical and Medical Counseling, Therapy, and Treatment ", 
+          "Clinical and Medical Counseling, Therapy, and Treatment", 
           "Clicinical and Medical Diagnostics"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6501,9 +6501,9 @@
         "organization_name": "Joanna Frost, MSW, LICSW", 
         "community": "Holyoke", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "referrals "
+          "Mental Health Services", 
+          "Counseling", 
+          "Referrals"
         ], 
         "web_url": "http://www.joannafrost.com/Joanna_Frost/Welcome.html", 
         "phone_numbers": [
@@ -6522,7 +6522,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6544,7 +6544,7 @@
         "organization_name": "Julie Dialessi-Lafley", 
         "community": "Springfield", 
         "services_offered": [
-          "Legal services"
+          "Legal Services"
         ], 
         "web_url": "http://www.baconwilson.com/attorneys/dialessi-lafley", 
         "phone_numbers": [
@@ -6598,7 +6598,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6620,7 +6620,7 @@
         "organization_name": "Kyle Guelcher", 
         "community": "Springfield", 
         "services_offered": [
-          "Legal services"
+          "Legal Services"
         ], 
         "web_url": "http://www.esq50.com/", 
         "phone_numbers": [
@@ -6637,7 +6637,7 @@
           "Legal Protective Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6657,7 +6657,7 @@
         "organization_name": "Liberty Street Clinic", 
         "community": "Springfield", 
         "services_offered": [
-          "Mental health services", 
+          "Mental Health Services", 
           "Healthcare"
         ], 
         "web_url": "http://bhninc.org/content/bhn-liberty-street-clinic", 
@@ -6678,7 +6678,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6702,7 +6702,7 @@
         "services_offered": [
           "Resources", 
           "Legal Services", 
-          "training and technical assistance"
+          "Training and Technical Assistance"
         ], 
         "web_url": "http://www.mass.gov/mcad/index.html", 
         "phone_numbers": [
@@ -6717,7 +6717,7 @@
           "Legal Protective Services"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6756,7 +6756,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6778,9 +6778,9 @@
         "organization_name": "Mount Tom Center for Mental Health and Recovery", 
         "community": "Holyoke", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "substance abuse services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://bhninc.org/content/mt-tom-center-mental-health-recovery", 
         "phone_numbers": [
@@ -6795,7 +6795,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6817,9 +6817,9 @@
         "organization_name": "Mount Tom City Clinic", 
         "community": "Holyoke", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "substance abuse services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://bhninc.org/content/mt-tom-city-clinic", 
         "phone_numbers": [
@@ -6834,7 +6834,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6856,12 +6856,12 @@
         "organization_name": "Out Now ", 
         "community": "Springfield", 
         "services_offered": [
-          "Support group", 
-          "social group", 
-          "leadership development", 
-          "public education", 
-          "resources", 
-          "recreation"
+          "Support Group", 
+          "Social Group", 
+          "Leadership Development", 
+          "Public Education", 
+          "Resources", 
+          "Recreation"
         ], 
         "web_url": "http://outnowyouth.org/who-we-are-2/our-home/", 
         "phone_numbers": [
@@ -6876,10 +6876,10 @@
         "service_class_level_2": "Para-professional Counseling, Therapy, and Support", 
         "service_classes": [
           "Community Prevention, Education, and Outreach", 
-          "Child/Adolescent Community Based Social Skills and Recreation"
+          "Child/adolescent Community Based Social Skills and Recreation"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -6899,7 +6899,7 @@
         "organization_name": "Pioneer Valley UniTy", 
         "community": "Springfield", 
         "services_offered": [
-          "support group"
+          "Support Group"
         ], 
         "web_url": "http://groups.yahoo.com/group/unity-of-the-pioneer-valley/", 
         "phone_numbers": [
@@ -6917,9 +6917,9 @@
           "Community Prevention, Education, and Outreach"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
-        "age_range": "parent", 
+        "age_range": "Parent", 
         "additional_notes": [
           "ally", 
           "This group is open to people who identify as transgender, as well as their allies, friends, significant others and family members. We are an inclusive group, and very much welcome supportive people from the larger GLBT community."
@@ -6940,9 +6940,9 @@
         "organization_name": "School Street Counseling Institute", 
         "community": "Springfield", 
         "services_offered": [
-          "mental health services", 
-          "counseling", 
-          "substance abuse services"
+          "Mental Health Services", 
+          "Counseling", 
+          "Substance Abuse Services"
         ], 
         "web_url": "http://bhninc.org/content/school-street-counseling", 
         "phone_numbers": [
@@ -6957,7 +6957,7 @@
           "Clinical and Medical Counseling, Therapy, and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -6979,8 +6979,8 @@
         "organization_name": "Stephanie Billings, Holyoke Health Center ", 
         "community": "Holyoke", 
         "services_offered": [
-          "healthcare", 
-          "primary care"
+          "Healthcare", 
+          "Primary Care"
         ], 
         "web_url": "http://www.hhcinc.org/", 
         "phone_numbers": [
@@ -6997,7 +6997,7 @@
           "Individual Primary Care Wellness"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": []
@@ -7017,8 +7017,8 @@
         "organization_name": "Tapestry Health", 
         "community": "Holyoke", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
@@ -7034,7 +7034,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -7056,8 +7056,8 @@
         "organization_name": "Tapestry Health", 
         "community": "Springfield", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
@@ -7073,7 +7073,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -7095,11 +7095,11 @@
         "organization_name": "Tapestry Health", 
         "community": "Springfield", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS", 
-          "referrals ", 
-          "housing services"
+          "Referrals", 
+          "Housing Services"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
         "phone_numbers": [
@@ -7114,7 +7114,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -7136,12 +7136,12 @@
         "organization_name": "La Voz", 
         "community": "Springfield", 
         "services_offered": [
-          "healthcare", 
-          "substance abuse services", 
+          "Healthcare", 
+          "Substance Abuse Services", 
           "HIV/AIDS", 
-          "mental heatlh services", 
-          "STI testing", 
-          "referrals"
+          "Mental Heatlh Services", 
+          "STI Testing", 
+          "Referrals"
         ], 
         "web_url": "http://www.tapestryhealth.org/index.php/services/prevention/la-voz", 
         "phone_numbers": [
@@ -7176,11 +7176,11 @@
         "organization_name": "Tapestry Health", 
         "community": "Springfield", 
         "services_offered": [
-          "healthcare", 
-          "STI testing", 
+          "Healthcare", 
+          "STI Testing", 
           "HIV/AIDS", 
-          "referrals ", 
-          "housing services"
+          "Referrals", 
+          "Housing Services"
         ], 
         "web_url": "http://www.tapestryhealth.org/", 
         "phone_numbers": [
@@ -7195,7 +7195,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -7217,9 +7217,9 @@
         "organization_name": "Zenaida \u201cSandy\u201d Ortega, Valley Psychiatric Services", 
         "community": "Springfield", 
         "services_offered": [
-          "mental health services", 
-          "healthcare", 
-          "counseling"
+          "Mental Health Services", 
+          "Healthcare", 
+          "Counseling"
         ], 
         "web_url": "http://valleypsychiatric.com/", 
         "phone_numbers": [
@@ -7235,7 +7235,7 @@
           "Clinical and Medical Diagnostics"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [
@@ -7257,8 +7257,8 @@
         "organization_name": "Eunice Aviles,. PsyD", 
         "community": "Springfield", 
         "services_offered": [
-          "mental health", 
-          "counseling"
+          "Mental Health", 
+          "Counseling"
         ], 
         "web_url": "http://euniceaviles.com/", 
         "phone_numbers": [
@@ -7278,7 +7278,7 @@
           "Clinical and Medical Counseling, Therapy and Treatment"
         ], 
         "target_populations": [
-          "LGBTQ youth"
+          "LGBTQ Youth"
         ], 
         "age_range": "", 
         "additional_notes": [


### PR DESCRIPTION
Bringing over the updated geojson file from some changes in the lgbtq-data repo.

https://github.com/codeforboston/lgbtq-data/commit/8395688c6a00fbee11f46642d3f3a4f7903904c5

Title Casing things and removing trailing spaces.
This cleans up some of the silly facet distinctions.
