### PR TITLE
make sure ID is a string

### DIFF
--- a/src/data/geojson.js
+++ b/src/data/geojson.js
@@ -11,10 +11,12 @@ define(function(require, exports, module) {
     };
 
     this.processData = function processData(data) {
-      // give each feature an ID if it doesn't have one already
+      // give each feature an string ID if it doesn't have one already
       data.features.forEach(function(feature, index) {
         if (!feature.id) {
           feature.id = 'finda-' + index;
+        } else {
+          feature.id = feature.id.toString();
         }
       });
       return data;

--- a/test/spec/data/geojson_spec.js
+++ b/test/spec/data/geojson_spec.js
@@ -21,7 +21,7 @@ define(function() {
           }]
         };
         var processed = this.component.processData(data);
-        expect(processed.features[0].id).toEqual(1);
+        expect(processed.features[0].id).toEqual('1');
       });
     });
   });


### PR DESCRIPTION
Some of the other code expects that the ID can be used as a key in an object, which numbers cannot.
