### PR TITLE
Switch to a different Tile Provider for map data.

### DIFF
--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -10,7 +10,7 @@ define(function(require, exports, module) {
 
   module.exports = flight.component(function map() {
     this.attributes({
-      tileUrl: 'http://a{s}.acetate.geoiq.com/tiles/acetate-hillshading/{z}/{x}/{y}.png',
+      tileUrl: 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
       tileAttribution: '&copy;2012 Esri & Stamen, Data from OSM and Natural Earth',
       tileSubdomains: '0123',
       tileMinZoom: 2,


### PR DESCRIPTION
geoiq.com is returning 503 errors saying that it's overloaded with traffic, so I'm proposing to switch to a different service that is [working](http://codefortuscaloosa.org/finda).
